### PR TITLE
Support zip and avoid reading files into memory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Simple binary to upload files over the API to BloodHound CE.
 ```
 
 By default the url is set to localhost:8080, and the dir is set to the current directory.
-For large environments, with collections above 15-20Gigs, it is recommended to split the files for upload into smaller chunks before uploading upload Otherwise the server will time out.
+For large environments, with collections above 15-20Gigs, it is recommended to split the files or zip them for upload into smaller chunks before uploading upload Otherwise the server will time out.
 
 Additionally, make sure to have enough RAM or SWAP space to handle the large files. Since the uploads need to be signed they'll need to be loaded into memory before being sent to the server.
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"BHCEupload/internal"
-	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
@@ -14,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -32,7 +32,7 @@ type BHResponse struct {
 	Data BHResponseData `json:"data"`
 }
 
-func QueryBloodhoundAPI(uri string, method string, body []byte, creds internal.Credentials) (BHResponse, error) {
+func QueryBloodhoundAPI(uri string, method string, body_file_name string, creds internal.Credentials) (BHResponse, error) {
 	// The first HMAC digest is the token key
 	digester := hmac.New(sha256.New, []byte(creds.BHTokenKey))
 
@@ -51,14 +51,32 @@ func QueryBloodhoundAPI(uri string, method string, body []byte, creds internal.C
 	// the signature to prevent replay attacks that seek to modify the payload of a signed request. In the case
 	// where there is no body content the HMAC digest is computed anyway, simply with no values written to the
 	// digester.
-	if body != nil {
-		digester.Write(body)
+	var body_reader io.Reader = nil
+
+	if body_file_name != "" {
+		// If body_file_name is not empty, we need to read the file and update the digester
+		// after that we seek back to the beginning of the file to be able to pass it to the request
+		var err error
+		body_reader_file, err := os.Open(body_file_name)
+		if err != nil {
+			return BHResponse{}, err
+		}
+		defer body_reader_file.Close()
+		_, err = io.Copy(digester, body_reader_file)
+		if err != nil {
+			return BHResponse{}, err
+		}
+		_, err = body_reader_file.Seek(0, io.SeekStart)
+		if err != nil {
+			return BHResponse{}, err
+		}
+		body_reader = body_reader_file
 	}
 
 	bhendpoint := fmt.Sprintf("%s%s", creds.BHUrl, uri)
 
 	// Perform the request with the signed and expected headers
-	req, err := http.NewRequest(method, bhendpoint, bytes.NewBuffer(body))
+	req, err := http.NewRequest(method, bhendpoint, body_reader)
 	if err != nil {
 		return BHResponse{}, err
 	}
@@ -67,7 +85,11 @@ func QueryBloodhoundAPI(uri string, method string, body []byte, creds internal.C
 	req.Header.Set("Authorization", fmt.Sprintf("bhesignature %s", creds.BHTokenID))
 	req.Header.Set("RequestDate", datetimeFormatted)
 	req.Header.Set("Signature", base64.StdEncoding.EncodeToString(digester.Sum(nil)))
-	req.Header.Set("Content-Type", "application/json")
+	if strings.HasSuffix(body_file_name, ".zip") {
+		req.Header.Set("Content-Type", "application/zip-compressed")
+	} else {
+		req.Header.Set("Content-Type", "application/json")
+	}
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
@@ -96,18 +118,18 @@ func QueryBloodhoundAPI(uri string, method string, body []byte, creds internal.C
 	return response, nil
 }
 
-func UploadData(data []byte, creds internal.Credentials) error {
-	upload_job, err := QueryBloodhoundAPI("/api/v2/file-upload/start", "POST", nil, creds)
+func UploadData(data_file_name string, creds internal.Credentials) error {
+	upload_job, err := QueryBloodhoundAPI("/api/v2/file-upload/start", "POST", "", creds)
 	if err != nil {
 		return err
 	}
 	job_id := upload_job.Data.Id
 	log.Println("Processing job ID:", job_id)
-	_, err = QueryBloodhoundAPI(fmt.Sprintf("/api/v2/file-upload/%d", job_id), "POST", data, creds)
+	_, err = QueryBloodhoundAPI(fmt.Sprintf("/api/v2/file-upload/%d", job_id), "POST", data_file_name, creds)
 	if err != nil {
 		return err
 	}
-	_, err = QueryBloodhoundAPI(fmt.Sprintf("/api/v2/file-upload/%d/end", job_id), "POST", nil, creds)
+	_, err = QueryBloodhoundAPI(fmt.Sprintf("/api/v2/file-upload/%d/end", job_id), "POST", "", creds)
 	if err != nil {
 		return err
 	}
@@ -116,11 +138,7 @@ func UploadData(data []byte, creds internal.Credentials) error {
 }
 
 func processFile(path string, creds internal.Credentials) error {
-	jsonFile, err := os.ReadFile(path)
-	if err != nil {
-		return err
-	}
-	err = UploadData(jsonFile, creds)
+	err := UploadData(path, creds)
 	if err != nil {
 		return err
 	}
@@ -154,11 +172,11 @@ func main() {
 			return err
 		}
 
-		if !info.IsDir() && filepath.Ext(path) == ".json" {
+		if !info.IsDir() && (filepath.Ext(path) == ".json" || filepath.Ext(path) == ".zip") {
 			sizeMB := float64(info.Size()) / 1024.0 / 1024.0
 			log.Printf("Uploading file %s, size: %.2f MB", path, sizeMB)
-			if sizeMB > 20000 {
-				log.Printf("File %s is quite large, will most likely fail, use chophound to make it smaller, skipping.", path)
+			if sizeMB > 20_000 {
+				log.Printf("File %s is quite large, will most likely fail, use chophound to make it smaller or compress it using zip, skipping.", path)
 				return nil
 			} else {
 				err := processFile(path, creds)


### PR DESCRIPTION
* Add support for uploading zip files. Setting the correct mime-type.
* Avoid reading the files into memory, instead calculate the check-sum by using io.Copy which reads it chunk by chunk. Also pass an io.Reader to the http request instead of a buffer with the full contents. This reduces memory usage for large files.